### PR TITLE
fix: use custom str enum for python 3.10

### DIFF
--- a/core/responses/base.py
+++ b/core/responses/base.py
@@ -1,9 +1,10 @@
-from enum import StrEnum, auto
+from enum import auto
 from http import HTTPStatus
 from typing import Generic, Optional, TypeVar
 
 from pydantic import BaseModel, Field
 
+from core.enum import StrEnum
 from core.i18n import translate as _
 
 T = TypeVar("T")


### PR DESCRIPTION
- use custom str enum for python 3.10.